### PR TITLE
Update Dockerfile

### DIFF
--- a/train-classifier/Dockerfile
+++ b/train-classifier/Dockerfile
@@ -11,7 +11,7 @@ ENV TRAINING_STEPS 1000
 VOLUME /output
 VOLUME /input
 
-RUN curl -O https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/examples/image_retraining/retrain.py
+RUN curl -O https://github.com/tensorflow/hub/blob/master/examples/image_retraining/retrain.py
 
 ENTRYPOINT python -m retrain \
   --how_many_training_steps="${TRAINING_STEPS}" \


### PR DESCRIPTION
Changed retrain.py URL since it was moved by tensorflow team.

From git repo:

This code has moved to https://github.com/tensorflow/hub/tree/master/examples/image_retraining
retrain.py is an example script that shows how one can adapt a pretrained network for other classification problems (including use with TFLite and quantization).
As of TensorFlow 1.7, it is recommended to use a pretrained network from TensorFlow Hub, using the new version of this example found in the location above, as explained in TensorFlow's revised image retraining tutorial.
Older versions of this example (using frozen GraphDefs instead of TensorFlow Hub modules) are available in the release branches of TensorFlow versions up to and including 1.7.