### PR TITLE
added paragraph about directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ You can provide your own training images from any source by creating the appropr
 3. `docker run -it -v $(pwd)/frame-extraction:/data frame-extraction`
 4. Retrieve the split video frames from [frame-extraction/frames/](./frame-extraction/frames), and place in the appropriate directory structure.
 
+## Building input directory structure
+
+You should have a folder containing class-named subfolders, each full
+of images for each label. The example folder would have a structure like this:
+
+
+    ~/example/bench/bench.jpg
+    ~/example/deadlift/deadlift.jpg
+    ~/example/squat/anotherphoto77.jpg
+
+The **subfolder names are important**, since *they define what label is applied to
+each image*, but the **filenames themselves don't matter**. 
+
 ## Training the Classifier
 
 Before training you must build the generic `train-classifier` Docker image:


### PR DESCRIPTION
The commented documentation in [retrain.py](https://github.com/tensorflow/hub/blob/master/examples/image_retraining/retrain.py) talks about how labels are given to tensorflow when doing transfert Learning:

> The top layer receives as input a 2048-dimensional vector (assuming
Inception V3) for each image. We train a softmax layer on top of this
representation. If the softmax layer contains N labels, this corresponds
to learning N + 2048*N model parameters for the biases and weights.



>Here's an example, which assumes you have a folder containing class-named
subfolders, each full of images for each label. The example folder flower_photos
should have a structure like this:


    ~/flower_photos/daisy/photo1.jpg
    ~/flower_photos/daisy/photo2.jpg
    ...
    ~/flower_photos/rose/anotherphoto77.jpg
    ...
    ~/flower_photos/sunflower/somepicture.jpg

> The subfolder names are important, since they define what label is applied to
each image, but the filenames themselves don't matter. (For a working example,
download http://download.tensorflow.org/example_images/flower_photos.tgz
and run  tar xzf flower_photos.tgz  to unpack it.)


> Once your images are prepared, and you have pip-installed tensorflow-hub and
a sufficiently recent version of tensorflow, you can run the training with a
command like this:

```bash
python retrain.py --image_dir ~/flower_photos
```

I understand that everything is explained in your [blog](https://kylewbanks.com/blog/tutorial-transfer-learning-retraining-inception-mobilenet-with-tensorflow-and-docker) but a little paragraph mentioning it in the README would be better.